### PR TITLE
Include instructions to add a plugin to the Marketplace in the response

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -410,7 +410,8 @@ git checkout master
 git pull
 git checkout -b bump_%[1]s-%[2]s
 make plugins.json
-git commit plugins.json -m "Bump version of %[1]s to %[2]s"
+make generate
+git commit plugins.json data/statik/statik.go -m "Bump version of %[1]s to %[2]s"
 git push --set-upstream origin bump_%[1]s-%[2]s
 git checkout master
 `, repo, tag)

--- a/server/server.go
+++ b/server/server.go
@@ -404,7 +404,17 @@ func cutPluginCommandF(w http.ResponseWriter, slashCommand *MMSlashCommand, tag,
 
 	go func() {
 		err := getReleaseArtifacts(tag, repo)
-		msg := fmt.Sprintf("Plugin was successufully signed and the signed artifacts uploaded to Github.\n**Tag: %s**\nRepo: %s", tag, repo)
+
+		marketplaceCommand := fmt.Sprintf(`
+git checkout master
+git pull
+git checkout -b bump_%[1]s-%[2]s
+make plugins.json
+git commit plugins.json -m "Bump version of %[1]s to %[2]s"
+git push --set-upstream origin bump_%[1]s-%[2]s
+git checkout master
+`, repo, tag)
+		msg = fmt.Sprintf("Plugin was successfully signed and the signed artifacts uploaded to Github.\nTag: **%s**\nRepo: **%s**\nTo add this release to the Plugin Marketplace run inside your local Marketplace repository:\n```%s\n```", tag, repo, marketplaceCommand)
 		color := "#0060aa"
 		if err != nil {
 			msg = fmt.Sprintf("Error while signing the plugin\nError: %s", err.Error())


### PR DESCRIPTION
#### Summary
This allows to just copy&past the command and add a plugin with minimal afford to the Marketplace.

![Screenshot from 2020-01-27 11-48-26](https://user-images.githubusercontent.com/16541325/73168952-46fa5000-40fb-11ea-9ea8-5c579a9be6d7.png)

Maybe the commands should even delete the local branch after the push. Thoughts?