### PR TITLE
Don't upload asc file to GitHub

### DIFF
--- a/server/plugin_release.go
+++ b/server/plugin_release.go
@@ -278,7 +278,6 @@ func copySignedFile(baseFilename, tempFolder string) ([]string, error) {
 
 	var filesToCopy []string
 	filesToCopy = append(filesToCopy, fmt.Sprintf("%s.sig", baseFilename))
-	filesToCopy = append(filesToCopy, fmt.Sprintf("%s.asc", baseFilename))
 
 	for _, file := range filesToCopy {
 		err := client.Connect()


### PR DESCRIPTION
#### Summary
There is not need to upload also push the asc file to GitHub. The Marketplace generator will fail if there are multiple signatures.

I did not test the changes as I don't habe the infrastructure to do this.

#### Ticket Link
https://community-release.mattermost.com/core/pl/s6dg9ddjcb8tmgfbdhp65sfk7h

