### PR TITLE
Renaming cutPlugin to cutplugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,19 +36,19 @@ $ make test
 3. Set Request URL to `http://localhost:5001/slash_command`
 4. Set Request Method to `POST`
 5. Click `Save`
-6. Navigate to any channel and type `/matterbuild cutPlugin --tag v0.4.1 --repo mattermost-plugin-demo`
+6. Navigate to any channel and type `/matterbuild cutplugin --tag v0.4.1 --repo mattermost-plugin-demo`
 
 ### Test via curl
 
 Invoke matterbuild commands using curl:
 
 ```
-curl -X POST http://localhost:5001/slash_command -d "command=/matterbuild&token=&user_id=" -d "text=cutPlugin+--tag+v0.4.1+--repo+mattermost-plugin-demo" 
+curl -X POST http://localhost:5001/slash_command -d "command=/matterbuild&token=&user_id=" -d "text=cutplugin+--tag+v0.4.1+--repo+mattermost-plugin-demo" 
 ```
 
-### Testing cutPlugin
+### Testing cutplugin
 
-To test the cutPlugin you have to:
+To test the cutplugin you have to:
 1. Connect to [Mattermost VPN](https://developers.mattermost.com/internal/infrastructure/vpn/)
 2. Get AWS [Vault](https://developers.mattermost.com/internal/infrastructure/vault/) credentials
 3. Signed public certificate by Vault

--- a/server/server.go
+++ b/server/server.go
@@ -170,7 +170,7 @@ func checkSlashPermissions(command *MMSlashCommand) *AppError {
 		return NewError("You don't have permissions to use this command.", nil)
 	}
 
-	if command.Command == "cut" || command.Command == "cutPlugin" {
+	if command.Command == "cut" || command.Command == "cutplugin" {
 		hasPermissions = false
 		for _, allowedUser := range Cfg.ReleaseUsers {
 			if allowedUser == command.UserId {
@@ -235,7 +235,7 @@ func slashCommandHandler(w http.ResponseWriter, r *http.Request, ps httprouter.P
 	}
 
 	var cutPluginCmd = &cobra.Command{
-		Use:   "cutPlugin [--tag] [--repo] [--force]",
+		Use:   "cutplugin [--tag] [--repo] [--force]",
 		Short: "Cut a release of any plugin under Mattermost Organization",
 		Long:  "Cut a release of any plugin under Mattermost Organization.",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -420,7 +420,7 @@ func cutPluginCommandF(w http.ResponseWriter, slashCommand *MMSlashCommand, tag,
 
 	go func() {
 		if err := cutPlugin(ctx, Cfg, client, Cfg.GithubOrg, repo, tag); err != nil {
-			LogError("failed to cutPlugin %s", err.Error())
+			LogError("failed to cutplugin %s", err.Error())
 			errMsg := fmt.Sprintf("Error while signing plugin\nError: %s", err.Error())
 			errColor := "#fc081c"
 			if err := PostExtraMessages(slashCommand.ResponseUrl, GenerateEnrichedSlashResponse("Plugin Release Process", errMsg, errColor, IN_CHANNEL)); err != nil {


### PR DESCRIPTION
Renaming `cutPlugin` to `cutplugin` 