### PR TITLE
IS-353: Use subcommand names for permission checks

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -170,7 +170,8 @@ func checkSlashPermissions(command *MMSlashCommand, rootCmd *cobra.Command) *App
 		return NewError("You don't have permissions to use this command.", nil)
 	}
 
-	if command.Command == "cut" || command.Command == "cutplugin" {
+	subCommand, _, _ := rootCmd.Find(strings.Fields(strings.TrimSpace(command.Text)))
+	if subCommand.Name() == "cut" || subCommand.Name() == "cutplugin" {
 		hasPermissions = false
 		for _, allowedUser := range Cfg.ReleaseUsers {
 			if allowedUser == command.UserId {

--- a/server/server.go
+++ b/server/server.go
@@ -145,7 +145,7 @@ func indexHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 	w.Write([]byte("This is the matterbuild server."))
 }
 
-func checkSlashPermissions(command *MMSlashCommand) *AppError {
+func checkSlashPermissions(command *MMSlashCommand, rootCmd *cobra.Command) *AppError {
 	hasPermissions := false
 	for _, allowedToken := range Cfg.AllowedTokens {
 		if allowedToken == command.Token {
@@ -295,15 +295,15 @@ func slashCommandHandler(w http.ResponseWriter, r *http.Request, ps httprouter.P
 		return
 	}
 
-	if err := checkSlashPermissions(command); err != nil {
+	rootCmd := initCommands(w, command)
+
+	if err := checkSlashPermissions(command, rootCmd); err != nil {
 		WriteErrorResponse(w, err)
 		return
 	}
 
 	// Output Buffer
 	outBuf := &bytes.Buffer{}
-
-	rootCmd := initCommands(w, command)
 
 	rootCmd.SetArgs(strings.Fields(strings.TrimSpace(command.Text)))
 	rootCmd.SetOutput(outBuf)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -29,3 +29,41 @@ func TestPluginTagRegex(t *testing.T) {
 		require.NotRegexp(t, regexp.MustCompile(pluginTagRegex), "    v552.522.532    ")
 	})
 }
+
+func TestCheckSlashPermissions(t *testing.T) {
+	t.Run("allowed commands", func(t *testing.T) {
+		Cfg = &MatterbuildConfig{
+			AllowedTokens: []string{"token"},
+			AllowedUsers:  []string{"userid1", "userid2"},
+			ReleaseUsers:  []string{"userid1", "userid3"},
+		}
+		commands := []*MMSlashCommand{
+			&MMSlashCommand{Command: "/matterbuild", Token: "token", UserId: "userid1", Text: "cut 0.0.0-rc0"},
+			&MMSlashCommand{Command: "/matterbuild", Token: "token", UserId: "userid1", Text: "cutplugin --tag v0.0.0-rc0 --repo testplugin"},
+		}
+		rootCmd := initCommands(nil, nil)
+		for _, command := range commands {
+			require.Nil(t, checkSlashPermissions(command, rootCmd))
+		}
+	})
+
+	t.Run("disallowed commands", func(t *testing.T) {
+		Cfg = &MatterbuildConfig{
+			AllowedTokens: []string{"token"},
+			AllowedUsers:  []string{"userid1", "userid2"},
+			ReleaseUsers:  []string{"userid1", "userid3"},
+		}
+		commands := []*MMSlashCommand{
+			&MMSlashCommand{Command: "/matterbuild", Token: "token", UserId: "userid2", Text: "cut 0.0.0-rc0"},
+			&MMSlashCommand{Command: "/matterbuild", Token: "token", UserId: "userid3", Text: "cut 0.0.0-rc0"},
+			&MMSlashCommand{Command: "/matterbuild", Token: "token", UserId: "userid4", Text: "cut 0.0.0-rc0"},
+			&MMSlashCommand{Command: "/matterbuild", Token: "token", UserId: "userid2", Text: "cutplugin --tag v0.0.0-rc0 --repo testplugin"},
+			&MMSlashCommand{Command: "/matterbuild", Token: "token", UserId: "userid3", Text: "cutplugin --tag v0.0.0-rc0 --repo testplugin"},
+			&MMSlashCommand{Command: "/matterbuild", Token: "token", UserId: "userid4", Text: "cutplugin --tag v0.0.0-rc0 --repo testplugin"},
+		}
+		rootCmd := initCommands(nil, nil)
+		for _, command := range commands {
+			require.NotNil(t, checkSlashPermissions(command, rootCmd))
+		}
+	})
+}


### PR DESCRIPTION
#### Summary
Changes the release permission checks to use subcommand names and adds relevant tests.

#### Ticket Link
https://mattermost.atlassian.net/browse/IS-353

