### PR TITLE
MM-24331 - matterbuild fails to fetch private repo assets

### DIFF
--- a/server/github_client.go
+++ b/server/github_client.go
@@ -5,6 +5,7 @@ package server
 
 import (
 	"context"
+	"io"
 	"os"
 
 	"github.com/google/go-github/github"
@@ -16,6 +17,7 @@ type GithubRepositoriesService interface {
 	ListTags(ctx context.Context, owner, repo string, opt *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error)
 	GetReleaseByTag(ctx context.Context, owner, repo, tag string) (*github.RepositoryRelease, *github.Response, error)
 	ListReleaseAssets(ctx context.Context, owner, repo string, id int64, opt *github.ListOptions) ([]*github.ReleaseAsset, *github.Response, error)
+	DownloadReleaseAsset(ctx context.Context, owner, repo string, id int64) (rc io.ReadCloser, redirectURL string, err error)
 	UploadReleaseAsset(ctx context.Context, owner, repo string, id int64, opt *github.UploadOptions, file *os.File) (*github.ReleaseAsset, *github.Response, error)
 	DeleteReleaseAsset(ctx context.Context, owner, repo string, id int64) (*github.Response, error)
 }

--- a/server/mocks/mock_github_repo.go
+++ b/server/mocks/mock_github_repo.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
 	github "github.com/google/go-github/github"
+	io "io"
 	os "os"
 	reflect "reflect"
 )
@@ -48,6 +49,22 @@ func (m *MockGithubRepositoriesService) DeleteReleaseAsset(arg0 context.Context,
 func (mr *MockGithubRepositoriesServiceMockRecorder) DeleteReleaseAsset(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteReleaseAsset", reflect.TypeOf((*MockGithubRepositoriesService)(nil).DeleteReleaseAsset), arg0, arg1, arg2, arg3)
+}
+
+// DownloadReleaseAsset mocks base method
+func (m *MockGithubRepositoriesService) DownloadReleaseAsset(arg0 context.Context, arg1, arg2 string, arg3 int64) (io.ReadCloser, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DownloadReleaseAsset", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// DownloadReleaseAsset indicates an expected call of DownloadReleaseAsset
+func (mr *MockGithubRepositoriesServiceMockRecorder) DownloadReleaseAsset(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadReleaseAsset", reflect.TypeOf((*MockGithubRepositoriesService)(nil).DownloadReleaseAsset), arg0, arg1, arg2, arg3)
 }
 
 // GetCommit mocks base method


### PR DESCRIPTION
#### Summary
Matterbuild was failing to fetch private repo assets. Switched to using github client's downloadasset API.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-24331