### PR TITLE
Add pipeline branch.

### DIFF
--- a/server/jenkins.go
+++ b/server/jenkins.go
@@ -77,6 +77,7 @@ func CutRelease(release string, rc string, isFirstMinorRelease bool, backportRel
 		"IS_DRY_RUN":             isDryRunStr,
 		"IS_DOT_RELEASE":         isDotReleaseStr,
 		"IS_BACKPORT":            isDotReleaseStr,
+		"PIP_BRANCH":             releaseBranch,
 	}
 
 	if server != "" {


### PR DESCRIPTION
#### Summary
Adding pipeline branch parameter to the cutting release functionality, so that versioning of pipeline code will be easier. This will probably result in a lot of "release-* not found branches" when releases are cut. 

#### Ticket Link
