### PR TITLE
mb cutplugin: support semver tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alecthomas/log4go v0.0.0-20180109082532-d146e6b86faa
 	github.com/aws/aws-sdk-go v1.25.35
 	github.com/beevik/etree v0.0.0-20170211013203-1095c300fba6
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/bndr/gojenkins v0.2.1-0.20170319170142-e382c473d545
 	github.com/eugenmayer/go-sshclient v0.0.0-20190908070959-1e92f9869e7c
 	github.com/golang/mock v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,9 @@ github.com/aws/aws-sdk-go v1.25.35 h1:fe2tJnqty/v/50pyngKdNk/NP8PFphYDA1Z7N3Eiii
 github.com/aws/aws-sdk-go v1.25.35/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beevik/etree v0.0.0-20170211013203-1095c300fba6 h1:/Z/G5QXOOUNRyaJOF6mEMZ9f2TOBGuTGTD/Y64Na/m8=
 github.com/beevik/etree v0.0.0-20170211013203-1095c300fba6/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
+github.com/blang/semver v1.1.0 h1:ol1rO7QQB5uy7umSNV7VAmLugfLRD+17sYJujRNYPhg=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bndr/gojenkins v0.2.1-0.20170319170142-e382c473d545 h1:55IlGc92KxqM5mT4Ut9RvMuGQPr0C2UE9HGr9OUaqm0=
 github.com/bndr/gojenkins v0.2.1-0.20170319170142-e382c473d545/go.mod h1:J2FxlujWW87NJJrdysyctcDllRVYUONGGlHX16134P4=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/server/server.go
+++ b/server/server.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/blang/semver"
 	"github.com/bndr/gojenkins"
 	"github.com/gorilla/schema"
 	"github.com/julienschmidt/httprouter"
@@ -26,8 +27,6 @@ const (
 	IN_CHANNEL = "in_channel"
 	EPHEMERAL  = "ephemeral"
 )
-
-const pluginTagRegex = `^v[0-9]+\.[0-9]+\.[0-9]+$`
 
 type MMSlashCommand struct {
 	ChannelId   string `schema:"channel_id"`
@@ -414,14 +413,17 @@ func cutReleaseCommandF(args []string, w http.ResponseWriter, slashCommand *MMSl
 }
 
 func cutPluginCommandF(w http.ResponseWriter, slashCommand *MMSlashCommand, tag, repo, commitSHA string, force bool) error {
-	pluginTag := regexp.MustCompile(pluginTagRegex)
 	if tag == "" {
 		WriteErrorResponse(w, NewError("Tag should not be empty", nil))
 		return nil
 	}
-	if !pluginTag.MatchString(tag) {
-		msg := fmt.Sprintf("Bad tag. maybe a typo? you set this tag %s but we expected something like v2.3.4", tag)
-		WriteErrorResponse(w, NewError(msg, nil))
+	if tag[0] != 'v' {
+		WriteErrorResponse(w, NewError("Tag must start with leading 'v'", nil))
+		return nil
+	}
+
+	if _, err := semver.Parse(tag[1:]); err != nil {
+		WriteErrorResponse(w, NewError(fmt.Sprintf("Tag must adhere to semver after leading 'v': ", err.Error()), nil))
 		return nil
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -423,7 +423,7 @@ func cutPluginCommandF(w http.ResponseWriter, slashCommand *MMSlashCommand, tag,
 	}
 
 	if _, err := semver.Parse(tag[1:]); err != nil {
-		WriteErrorResponse(w, NewError(fmt.Sprintf("Tag must adhere to semver after leading 'v': ", err.Error()), nil))
+		WriteErrorResponse(w, NewError(fmt.Sprintf("Tag must adhere to semver after leading 'v': %s", err.Error()), nil))
 		return nil
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -4,31 +4,10 @@
 package server
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
-
-func TestPluginTagRegex(t *testing.T) {
-	t.Run("valid tags", func(t *testing.T) {
-		require.Regexp(t, regexp.MustCompile(pluginTagRegex), "v5.2.3")
-		require.Regexp(t, regexp.MustCompile(pluginTagRegex), "v55.52.53")
-		require.Regexp(t, regexp.MustCompile(pluginTagRegex), "v552.522.532")
-	})
-
-	t.Run("invalid tags", func(t *testing.T) {
-		require.NotRegexp(t, regexp.MustCompile(pluginTagRegex), "5.2.3")
-		require.NotRegexp(t, regexp.MustCompile(pluginTagRegex), "5a2.3")
-		require.NotRegexp(t, regexp.MustCompile(pluginTagRegex), "5.2a3")
-		require.NotRegexp(t, regexp.MustCompile(pluginTagRegex), " v 5 . 2 . 3 ")
-		require.NotRegexp(t, regexp.MustCompile(pluginTagRegex), "v55..52.53")
-		require.NotRegexp(t, regexp.MustCompile(pluginTagRegex), "v552.522..532")
-		require.NotRegexp(t, regexp.MustCompile(pluginTagRegex), "zzzv552.522.532")
-		require.NotRegexp(t, regexp.MustCompile(pluginTagRegex), "123zzzv552.522.532")
-		require.NotRegexp(t, regexp.MustCompile(pluginTagRegex), "    v552.522.532    ")
-	})
-}
 
 func TestCheckSlashPermissions(t *testing.T) {
 	t.Run("allowed commands", func(t *testing.T) {


### PR DESCRIPTION
#### Summary
For `/mb cutplugin`, don't restrict tags to just `vX.Y.Z` -- support semver with a leading `v` to allow alpha tagging as necessary.