### PR TITLE
Add release targets and script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ mocks:
 #####################
 PATTERN =
 
-# if the last relase was alpha, beta or rc, 'release' target has to used with current
+# if the last release was alpha, beta or rc, 'release' target has to used with current
 # cycle release. For example if latest tag is v0.8.0-rc.2 and v0.8.0 GA needs to get
 # released the following should be executed: "make release version=0.8.0"
 ## Prepare release

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,35 @@ mocks:
 	mockgen -package mocks -destination server/mocks/mock_github_search.go github.com/mattermost/matterbuild/server GithubSearchService
 	mockgen -package mocks -destination server/mocks/mock_github_git.go github.com/mattermost/matterbuild/server GithubGitService
 
+#####################
+## Release targets ##
+#####################
+PATTERN =
+
+# if the last relase was alpha, beta or rc, 'release' target has to used with current
+# cycle release. For example if latest tag is v0.8.0-rc.2 and v0.8.0 GA needs to get
+# released the following should be executed: "make release version=0.8.0"
+## Prepare release
+.PHONY: release
+release: VERSION ?= $(shell git describe --tags 2>/dev/null | sed 's/^v//' | awk -F'[ .]' '{print $(PATTERN)}')
+release:
+	@ ./scripts/release.sh "$(VERSION)" "1"
+
+## Prepare Patch release
+.PHONY: patch
+patch: PATTERN = '\$$1\".\"\$$2\".\"\$$3+1'
+patch: release
+
+## Prepare Minor release
+.PHONY: minor
+minor: PATTERN = '\$$1\".\"\$$2+1\".0\"'
+minor: release
+
+## Prepare Major release
+.PHONY: major
+major: PATTERN = '\$$1+1\".0.0\"'
+major: release
+
 # Help documentation à la https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help:
 	@cat Makefile | grep -v '\.PHONY' |  grep -v '\help:' | grep -B1 -E '^[a-zA-Z_.-]+:.*' | sed -e "s/:.*//" | sed -e "s/^## //" |  grep -v '\-\-' | uniq | sed '1!G;h;$$!d' | awk 'NR%2{printf "\033[36m%-30s\033[0m",$$0;next;}1' | sort

--- a/Makefile
+++ b/Makefile
@@ -97,9 +97,9 @@ mocks:
 #####################
 PATTERN =
 
-# if the last release was alpha, beta or rc, 'release' target has to used with current
+# if the last release was alpha, beta or rc, 'release' target has to be used with current
 # cycle release. For example if latest tag is v0.8.0-rc.2 and v0.8.0 GA needs to get
-# released the following should be executed: "make release version=0.8.0"
+# released the following should be executed: "make release VERSION=0.8.0"
 ## Prepare release
 .PHONY: release
 release: VERSION ?= $(shell git describe --tags 2>/dev/null | sed 's/^v//' | awk -F'[ .]' '{print $(PATTERN)}')

--- a/README.md
+++ b/README.md
@@ -105,3 +105,11 @@ To test the cutplugin you have to:
 "PluginSigningAWSRegion": "us-east-1",
 "PluginSigningAWSS3PluginBucket": "mattermost-toolkit-dev"
 ```
+
+## Releasing
+
+There are helper Makefile targets to cut a release following semver:
+
+- `make patch`: to cut a patch release
+- `make minor`: to cut a minor release
+- `make major`: to cut a major release

--- a/deploy/overlays/prod/kustomization.yaml
+++ b/deploy/overlays/prod/kustomization.yaml
@@ -14,4 +14,4 @@ resources:
 images:
 - name: mattermost/matterbuild
   newName: mattermost/matterbuild
-  digest: sha256:ea6b92423a5d8464255f42cfd28157d888d501f74f2c3ae28922817404f6109f
+  newTag: 0.1.0

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ -z "${CURRENT_BRANCH}" -o "${CURRENT_BRANCH}" != "master" ]; then
+    echo "Error: The current branch is '${CURRENT_BRANCH}', switch to 'master' to do the release."
+    exit 1
+fi
+
+if [ -n "$(git status --short)" ]; then
+    echo "Error: There are untracked/modified changes, commit or discard them before the release."
+    exit 1
+fi
+
+CURRENT_VERSION=""
+RELEASE_VERSION=$1
+FROM_MAKEFILE=$2
+
+if [ -z "${RELEASE_VERSION}" ]; then
+    if [ -z "${FROM_MAKEFILE}" ]; then
+        echo "Error: VERSION is missing. e.g. ./release.sh <version>"
+    else
+        echo "Error: missing value for 'version'. e.g. 'make release version=x.y.z'"
+    fi
+    exit 1
+fi
+
+if [ -z "${CURRENT_VERSION}" ]; then
+    CURRENT_VERSION=$(git describe --tags --exact-match 2>/dev/null || git describe --tags 2>/dev/null)
+fi
+if [ -z "${CURRENT_VERSION}" ]; then
+    echo "Error: current version not found."
+    exit 1
+fi
+
+if [ "v${RELEASE_VERSION}" = "${CURRENT_VERSION}" ]; then
+    echo "Error: provided version (v${RELEASE_VERSION}) already exists."
+    exit 1
+fi
+
+if [ $(git describe --tags "v${RELEASE_VERSION}" 2>/dev/null) ]; then
+    echo "Error: provided version (v${RELEASE_VERSION}) already exists."
+    exit 1
+fi
+
+PWD=$(cd $(dirname "$0") && pwd -P)
+
+# get closest GA tag, ignore alpha, beta and rc tags
+function getClosestVersion() {
+    for t in $(git tag --sort=-creatordate); do
+        tag="$t"
+        if [[ $tag == *"-alpha"* || $tag == *"-beta"* || $tag == *"-rc"* ]]; then
+            continue
+        fi
+        break
+    done
+    echo "$tag"
+}
+CLOSEST_VERSION=$(getClosestVersion | sed 's/^v//')
+
+# Bump the released version
+sed -i -E 's|'${CLOSEST_VERSION}'|'${RELEASE_VERSION}'|g' deploy/overlays/prod/kustomization.yaml
+
+# Commit changes
+printf "\033[36m==> %s\033[0m\n" "Commit changes for release version v${RELEASE_VERSION}"
+git add deploy/overlays/prod/kustomization.yaml
+git commit -m "Release version v${RELEASE_VERSION}"
+
+printf "\033[36m==> %s\033[0m\n" "Push commits for v${RELEASE_VERSION}"
+git push origin master
+
+# Tag the release
+printf "\033[36m==> %s\033[0m\n" "Tag release v${RELEASE_VERSION}"
+git tag --annotate --message "v${RELEASE_VERSION} Release" "v${RELEASE_VERSION}"
+
+printf "\033[36m==> %s\033[0m\n" "Push tag release v${RELEASE_VERSION}"
+git push origin v${RELEASE_VERSION}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,6 +4,7 @@ set -o errexit
 set -o pipefail
 
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
 if [ -z "${CURRENT_BRANCH}" -o "${CURRENT_BRANCH}" != "master" ]; then
     echo "Error: The current branch is '${CURRENT_BRANCH}', switch to 'master' to do the release."
     exit 1
@@ -14,24 +15,22 @@ if [ -n "$(git status --short)" ]; then
     exit 1
 fi
 
-CURRENT_VERSION=""
+CURRENT_VERSION=$(git describe --tags --exact-match 2>/dev/null || git describe --tags 2>/dev/null)
+
+if [ -z "${CURRENT_VERSION}" ]; then
+    echo "Error: current version not found."
+    exit 1
+fi
+
 RELEASE_VERSION=$1
 FROM_MAKEFILE=$2
 
 if [ -z "${RELEASE_VERSION}" ]; then
     if [ -z "${FROM_MAKEFILE}" ]; then
-        echo "Error: VERSION is missing. e.g. ./release.sh <version>"
+        echo "Error: VERSION is missing. e.g. ./release.sh <VERSION>"
     else
-        echo "Error: missing value for 'version'. e.g. 'make release version=x.y.z'"
+        echo "Error: missing value for 'version'. e.g. 'make release VERSION=x.y.z'"
     fi
-    exit 1
-fi
-
-if [ -z "${CURRENT_VERSION}" ]; then
-    CURRENT_VERSION=$(git describe --tags --exact-match 2>/dev/null || git describe --tags 2>/dev/null)
-fi
-if [ -z "${CURRENT_VERSION}" ]; then
-    echo "Error: current version not found."
     exit 1
 fi
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Add helper targets in Makefile to cut a release:

- `make patch`: to cut a patch release
- `make minor`: to cut a minor release
- `make major`: to cut a major release

This is particularly important because on each release `deploy/overlays/prod/kustomization.yaml` must be updated and these are to make sure that that's never skipped.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

