### PR TITLE
Use Debian buster-slim as base Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,16 @@ COPY go.sum .
 RUN go mod download
 
 COPY . .
-RUN make build
+RUN CGO_ENABLED=0 make build
 
 ################
 
-FROM alpine:3.12.0
+FROM debian:buster-slim
 
-RUN apk --no-cache add ca-certificates
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y ca-certificates && \
+    apt-get clean all && \
+    rm -rf /var/cache/apt/
 
 COPY --from=builder /go/src/matterbuild/dist/matterbuild /usr/local/bin/
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
There are OS package dependencies (specifically `tar`) which requires a GNU compatible version of package which is not available in `alpine`.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

