### PR TITLE
[MM-26990] Include '@username' in matterbuild's cutplugin slashcommand response

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -456,7 +456,7 @@ func cutPluginCommandF(w http.ResponseWriter, slashCommand *MMSlashCommand, tag,
 	}
 
 	username := slashCommand.Username
-	msg := fmt.Sprintf("Username: `@%s`\nTag %s created by. Waiting for the artifacts to sign and publish.\nWill report back when the process completes.\nGrab :coffee: and a :doughnut: ", username, tag)
+	msg := fmt.Sprintf("`@%s` triggered a plugin release process.\nTag %s created. Waiting for the artifacts to sign and publish.\nWill report back when the process completes.\nGrab :coffee: and a :doughnut: ", username, tag)
 	if err := createTag(ctx, client, Cfg.GithubOrg, repo, tag, commitSHA); errors.Is(err, ErrTagExists) {
 		if !force {
 			WriteErrorResponse(w, NewError(fmt.Errorf("Username: `@%s`\nTag %s already exists, not generating any artifacts. Use --force to regenerate artifacts.", username, tag).Error(), nil))

--- a/server/server.go
+++ b/server/server.go
@@ -491,7 +491,7 @@ func cutPluginCommandF(w http.ResponseWriter, slashCommand *MMSlashCommand, tag,
 
 		branch := fmt.Sprintf("add_%s_%s", repo, tag)
 
-		// the string below has been left non-indented to avoid introducing unintentional spaces
+		// Purposefully left unindented to avoid introducing extra spaces when posting the message.
 		marketplaceCommand := fmt.Sprintf(`
 git checkout production
 git pull

--- a/server/server.go
+++ b/server/server.go
@@ -490,17 +490,19 @@ func cutPluginCommandF(w http.ResponseWriter, slashCommand *MMSlashCommand, tag,
 		}
 
 		branch := fmt.Sprintf("add_%s_%s", repo, tag)
+
+		// this has been left non-indented to avoid introducing unintended spaces visible to the user
 		marketplaceCommand := fmt.Sprintf(`
-			git checkout production
-			git pull
-			git checkout -b %[3]s
-			make plugins.json
-			make generate
-			git commit plugins.json data/statik/statik.go -m "Add %[1]s of %[2]s to the Marketplace"
-			git push --set-upstream origin %[3]s
-			git checkout master
-			`, tag, repo, branch,
-		)
+git checkout production
+git pull
+git checkout -b %[3]s
+make plugins.json
+make generate
+git commit plugins.json data/statik/statik.go -m "Add %[1]s of %[2]s to the Marketplace"
+git push --set-upstream origin %[3]s
+git checkout master
+`, tag, repo, branch)
+
 		url := fmt.Sprintf(
 			"https://github.com/mattermost/mattermost-marketplace/compare/production...%s?quick_pull=1&labels=3:+QA+Review,2:+Dev+Review",
 			branch,

--- a/server/server.go
+++ b/server/server.go
@@ -456,13 +456,13 @@ func cutPluginCommandF(w http.ResponseWriter, slashCommand *MMSlashCommand, tag,
 	}
 
 	username := slashCommand.Username
-	msg := fmt.Sprintf("@%s\nTag %s created by. Waiting for the artifacts to sign and publish.\nWill report back when the process completes.\nGrab :coffee: and a :doughnut: ", username, tag)
+	msg := fmt.Sprintf("Username: `@%s`\nTag %s created by. Waiting for the artifacts to sign and publish.\nWill report back when the process completes.\nGrab :coffee: and a :doughnut: ", username, tag)
 	if err := createTag(ctx, client, Cfg.GithubOrg, repo, tag, commitSHA); errors.Is(err, ErrTagExists) {
 		if !force {
-			WriteErrorResponse(w, NewError(fmt.Errorf("@%s\nTag %s already exists, not generating any artifacts. Use --force to regenerate artifacts.", username, tag).Error(), nil))
+			WriteErrorResponse(w, NewError(fmt.Errorf("Username: `@%s`\nTag %s already exists, not generating any artifacts. Use --force to regenerate artifacts.", username, tag).Error(), nil))
 			return nil
 		}
-		msg = fmt.Sprintf("@%s\nTag %s exists. Waiting for the artifacts to sign and publish.\nWill report back when the process completes.\nGrab :coffee: and a :doughnut: ", username, tag)
+		msg = fmt.Sprintf("Username: `@%s`\nTag %s exists. Waiting for the artifacts to sign and publish.\nWill report back when the process completes.\nGrab :coffee: and a :doughnut: ", username, tag)
 	} else if err != nil {
 		WriteErrorResponse(w, NewError(err.Error(), nil))
 		return nil
@@ -491,7 +491,7 @@ func cutPluginCommandF(w http.ResponseWriter, slashCommand *MMSlashCommand, tag,
 
 		branch := fmt.Sprintf("add_%s_%s", repo, tag)
 
-		// this has been left non-indented to avoid introducing unintended spaces visible to the user
+		// the string below has been left non-indented to avoid introducing unintentional spaces
 		marketplaceCommand := fmt.Sprintf(`
 git checkout production
 git pull
@@ -508,7 +508,7 @@ git checkout master
 			branch,
 		)
 		msg = fmt.Sprintf(
-			"@%s\nPlugin was successfully signed and uploaded to Github and S3.\nTag: **%s**\nRepo: **%s**\n[Release Link](%s)\nTo add this release to the Plugin Marketplace run inside your local Marketplace repository:\n```%s\n```\nUse %s to open a Pull Request.",
+			"Username: `@%s`\nPlugin was successfully signed and uploaded to Github and S3.\nTag: **%s**\nRepo: **%s**\n[Release Link](%s)\nTo add this release to the Plugin Marketplace run inside your local Marketplace repository:\n```%s\n```\nUse %s to open a Pull Request.",
 			username, tag, repo, releaseURL, marketplaceCommand, url,
 		)
 		color := "#0060aa"

--- a/server/server.go
+++ b/server/server.go
@@ -456,10 +456,10 @@ func cutPluginCommandF(w http.ResponseWriter, slashCommand *MMSlashCommand, tag,
 	}
 
 	username := slashCommand.Username
-	msg := fmt.Sprintf("`@%s` triggered a plugin release process.\nTag %s created. Waiting for the artifacts to sign and publish.\nWill report back when the process completes.\nGrab :coffee: and a :doughnut: ", username, tag)
+	msg := fmt.Sprintf("@%s triggered a plugin release process.\nTag %s created. Waiting for the artifacts to sign and publish.\nWill report back when the process completes.\nGrab :coffee: and a :doughnut: ", username, tag)
 	if err := createTag(ctx, client, Cfg.GithubOrg, repo, tag, commitSHA); errors.Is(err, ErrTagExists) {
 		if !force {
-			WriteErrorResponse(w, NewError(fmt.Errorf("`@%s` Tag %s already exists, not generating any artifacts. Use --force to regenerate artifacts.", username, tag).Error(), nil))
+			WriteErrorResponse(w, NewError(fmt.Errorf("@%s Tag %s already exists, not generating any artifacts. Use --force to regenerate artifacts.", username, tag).Error(), nil))
 			return nil
 		}
 		msg = fmt.Sprintf("@%s Tag %s already exists. Waiting for the artifacts to sign and publish.\nWill report back when the process completes.\nGrab :coffee: and a :doughnut: ", username, tag)

--- a/server/server.go
+++ b/server/server.go
@@ -459,10 +459,10 @@ func cutPluginCommandF(w http.ResponseWriter, slashCommand *MMSlashCommand, tag,
 	msg := fmt.Sprintf("`@%s` triggered a plugin release process.\nTag %s created. Waiting for the artifacts to sign and publish.\nWill report back when the process completes.\nGrab :coffee: and a :doughnut: ", username, tag)
 	if err := createTag(ctx, client, Cfg.GithubOrg, repo, tag, commitSHA); errors.Is(err, ErrTagExists) {
 		if !force {
-			WriteErrorResponse(w, NewError(fmt.Errorf("Username: `@%s`\nTag %s already exists, not generating any artifacts. Use --force to regenerate artifacts.", username, tag).Error(), nil))
+			WriteErrorResponse(w, NewError(fmt.Errorf("`@%s` Tag %s already exists, not generating any artifacts. Use --force to regenerate artifacts.", username, tag).Error(), nil))
 			return nil
 		}
-		msg = fmt.Sprintf("Username: `@%s`\nTag %s exists. Waiting for the artifacts to sign and publish.\nWill report back when the process completes.\nGrab :coffee: and a :doughnut: ", username, tag)
+		msg = fmt.Sprintf("@%s Tag %s already exists. Waiting for the artifacts to sign and publish.\nWill report back when the process completes.\nGrab :coffee: and a :doughnut: ", username, tag)
 	} else if err != nil {
 		WriteErrorResponse(w, NewError(err.Error(), nil))
 		return nil
@@ -508,7 +508,7 @@ git checkout master
 			branch,
 		)
 		msg = fmt.Sprintf(
-			"Username: `@%s`\nPlugin was successfully signed and uploaded to Github and S3.\nTag: **%s**\nRepo: **%s**\n[Release Link](%s)\nTo add this release to the Plugin Marketplace run inside your local Marketplace repository:\n```%s\n```\nUse %s to open a Pull Request.",
+			"@%s A Plugin was successfully signed and uploaded to Github and S3.\nTag: **%s**\nRepo: **%s**\n[Release Link](%s)\nTo add this release to the Plugin Marketplace run inside your local Marketplace repository:\n```%s\n```\nUse %s to open a Pull Request.",
 			username, tag, repo, releaseURL, marketplaceCommand, url,
 		)
 		color := "#0060aa"

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -16,10 +16,12 @@ func TestCheckSlashPermissions(t *testing.T) {
 			AllowedUsers:  []string{"userid1", "userid2"},
 			ReleaseUsers:  []string{"userid1", "userid3"},
 		}
+
 		commands := []*MMSlashCommand{
-			&MMSlashCommand{Command: "/matterbuild", Token: "token", UserId: "userid1", Text: "cut 0.0.0-rc0"},
-			&MMSlashCommand{Command: "/matterbuild", Token: "token", UserId: "userid1", Text: "cutplugin --tag v0.0.0-rc0 --repo testplugin"},
+			{Command: "/matterbuild", Token: "token", UserId: "userid1", Text: "cut 0.0.0-rc0"},
+			{Command: "/matterbuild", Token: "token", UserId: "userid1", Text: "cutplugin --tag v0.0.0-rc0 --repo testplugin"},
 		}
+
 		rootCmd := initCommands(nil, nil)
 		for _, command := range commands {
 			require.Nil(t, checkSlashPermissions(command, rootCmd))
@@ -33,12 +35,12 @@ func TestCheckSlashPermissions(t *testing.T) {
 			ReleaseUsers:  []string{"userid1", "userid3"},
 		}
 		commands := []*MMSlashCommand{
-			&MMSlashCommand{Command: "/matterbuild", Token: "token", UserId: "userid2", Text: "cut 0.0.0-rc0"},
-			&MMSlashCommand{Command: "/matterbuild", Token: "token", UserId: "userid3", Text: "cut 0.0.0-rc0"},
-			&MMSlashCommand{Command: "/matterbuild", Token: "token", UserId: "userid4", Text: "cut 0.0.0-rc0"},
-			&MMSlashCommand{Command: "/matterbuild", Token: "token", UserId: "userid2", Text: "cutplugin --tag v0.0.0-rc0 --repo testplugin"},
-			&MMSlashCommand{Command: "/matterbuild", Token: "token", UserId: "userid3", Text: "cutplugin --tag v0.0.0-rc0 --repo testplugin"},
-			&MMSlashCommand{Command: "/matterbuild", Token: "token", UserId: "userid4", Text: "cutplugin --tag v0.0.0-rc0 --repo testplugin"},
+			{Command: "/matterbuild", Token: "token", UserId: "userid2", Text: "cut 0.0.0-rc0"},
+			{Command: "/matterbuild", Token: "token", UserId: "userid3", Text: "cut 0.0.0-rc0"},
+			{Command: "/matterbuild", Token: "token", UserId: "userid4", Text: "cut 0.0.0-rc0"},
+			{Command: "/matterbuild", Token: "token", UserId: "userid2", Text: "cutplugin --tag v0.0.0-rc0 --repo testplugin"},
+			{Command: "/matterbuild", Token: "token", UserId: "userid3", Text: "cutplugin --tag v0.0.0-rc0 --repo testplugin"},
+			{Command: "/matterbuild", Token: "token", UserId: "userid4", Text: "cutplugin --tag v0.0.0-rc0 --repo testplugin"},
 		}
 		rootCmd := initCommands(nil, nil)
 		for _, command := range commands {


### PR DESCRIPTION
#### Summary
Includes the username in cutplugin slash command response for better visibility.

#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/MM-26990
Fixes https://github.com/mattermost/mattermost-server/issues/15045

#### Notes
I've also fixed some warnings in `server/server_test.go` and tried to tidy up some of the long one-liner statements.
