### PR TITLE
Add version info, commit hash and build date to binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,20 @@
+# Project variables
+NAME        := matterbuild
+AUTHOR      := mattermost
+URL         := https://github.com/$(AUTHOR)/$(NAME)
+
+# Build variables
+COMMIT_HASH  ?= $(shell git rev-parse --short HEAD 2>/dev/null)
+BUILD_DATE   ?= $(shell date +%FT%T%z)
+CUR_VERSION  ?= $(shell git describe --tags --exact-match 2>/dev/null || git describe --tags 2>/dev/null || echo "v0.0.0-$(COMMIT_HASH)")
+
+# Go variables
+LDFLAGS :="
+LDFLAGS += -X github.com/$(AUTHOR)/$(NAME)/version.version=$(CUR_VERSION)
+LDFLAGS += -X github.com/$(AUTHOR)/$(NAME)/version.commitHash=$(COMMIT_HASH)
+LDFLAGS += -X github.com/$(AUTHOR)/$(NAME)/version.buildDate=$(BUILD_DATE)
+LDFLAGS +="
+
 GO ?= $(shell command -v go 2> /dev/null)
 
 PACKAGES=$(shell go list ./...)
@@ -67,7 +84,7 @@ test:
 .PHONY: build
 build: clean
 	@echo Building
-	$(GO) build -o dist/matterbuild
+	$(GO) build -ldflags $(LDFLAGS) -o dist/matterbuild
 
 # Docker variables
 DEFAULT_TAG  ?= $(shell git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD 2>/dev/null)

--- a/server/server.go
+++ b/server/server.go
@@ -6,6 +6,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -22,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/mattermost/matterbuild/utils"
+	"github.com/mattermost/matterbuild/version"
 )
 
 const (
@@ -130,6 +132,10 @@ type Config struct {
 	CACrtPath bool
 }
 
+type healthResponse struct {
+	Info *version.Info `json:"info"`
+}
+
 var config = &Config{}
 
 func Start() {
@@ -155,7 +161,12 @@ func indexHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 	w.Write([]byte("This is the matterbuild server."))
 }
 func healthHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	w.Write([]byte("Healthy!"))
+	err := json.NewEncoder(w).Encode(healthResponse{Info: version.Full()})
+	if err != nil {
+		LogError(err.Error())
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 }
 
 func checkSlashPermissions(command *MMSlashCommand, rootCmd *cobra.Command) *AppError {

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package version
+
+import (
+	"time"
+)
+
+// current version
+const dev = "dev"
+
+// Provisioned by ldflags
+var (
+	version    string
+	commitHash string
+	buildDate  string
+)
+
+// Info represents full version information, including commit hash and build date
+type Info struct {
+	Version string `json:"version"`
+	Hash    string `json:"hash"`
+	Date    string `json:"date"`
+}
+
+func init() {
+	// Load defaults for info variables
+	if version == "" {
+		version = dev
+	}
+	if commitHash == "" {
+		commitHash = dev
+	}
+	if buildDate == "" {
+		buildDate = time.Now().Format(time.RFC3339)
+	}
+}
+
+// Full return the full information including version, commit hash and build date
+func Full() *Info {
+	return &Info{
+		Version: version,
+		Hash:    commitHash,
+		Date:    buildDate,
+	}
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Add version information including actual version, commit hash, and build date to the built binary through ldfalgs on build time.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

