### PR TITLE
[MM-33116] Drop `make generate` from Marketplace instructions

### DIFF
--- a/server/plugin_release.go
+++ b/server/plugin_release.go
@@ -797,8 +797,7 @@ go run ./cmd/generator/ add %[2]s %[1]s [--official|--community] [--beta] [--ent
 		"Then review your changes by running `git diff plugins.json`\n" +
 		codeSeperator +
 		fmt.Sprintf(`
-make generate
-git commit plugins.json data/statik/statik.go -m "Add %[1]s of %[2]s to the Marketplace"
+git commit plugins.json -m "Add %[1]s of %[2]s to the Marketplace"
 git push --set-upstream origin %[3]s
 git checkout master
 `, tag, repo, branch) +

--- a/server/plugin_release_test.go
+++ b/server/plugin_release_test.go
@@ -397,8 +397,7 @@ go run ./cmd/generator/ add mattermost-plugin-jira v3.0.0 [--official|--communit
 		"You might want to use other flag like `--beta` to add a `Beta` label, or `--enterprise` for plugins that require an E20 license.\n" +
 		"\n" +
 		"Then review your changes by running `git diff plugins.json`" + "\n```\n" +
-		`make generate
-git commit plugins.json data/statik/statik.go -m "Add v3.0.0 of mattermost-plugin-jira to the Marketplace"
+		`git commit plugins.json -m "Add v3.0.0 of mattermost-plugin-jira to the Marketplace"
 git push --set-upstream origin add_mattermost-plugin-jira_v3.0.0
 git checkout master` + "\n```\n" +
 		`Use https://github.com/mattermost/mattermost-marketplace/compare/production...add_mattermost-plugin-jira_v3.0.0?quick_pull=1&labels=3:+QA+Review,2:+Dev+Review to open a Pull Request.`


### PR DESCRIPTION
#### Summary
`make generate` is not longer need and hence should be dropped from the instructions.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33116

