### PR TITLE
Adds support for the --asset-name flag when cutting a plugin

### DIFF
--- a/server/plugin_release.go
+++ b/server/plugin_release.go
@@ -44,7 +44,7 @@ var ErrTagExists = errors.New("tag already exists")
 // This generates:
 // 1. Plugin signature (uploaded to github)
 // 2. Platform specific plugin tars and their signatures (uploaded to s3 release bucket)
-func cutPlugin(ctx context.Context, cfg *MatterbuildConfig, client *GithubClient, owner, repositoryName, tag string, preRelease bool) error {
+func cutPlugin(ctx context.Context, cfg *MatterbuildConfig, client *GithubClient, owner, repositoryName, tag, assetName string, preRelease bool) error {
 	pluginRelease, err := getPluginRelease(ctx, client, owner, repositoryName, tag)
 	if err != nil {
 		return errors.Wrap(err, "failed to get plugin release")
@@ -56,7 +56,7 @@ func cutPlugin(ctx context.Context, cfg *MatterbuildConfig, client *GithubClient
 		}
 	}
 
-	pluginAsset, err := getPluginAsset(ctx, pluginRelease)
+	pluginAsset, err := getPluginAsset(ctx, pluginRelease, assetName)
 	if err != nil {
 		return errors.Wrap(err, "failed to get plugin asset")
 	}
@@ -539,9 +539,15 @@ func getPluginRelease(ctx context.Context, githubClient *GithubClient, owner, re
 	}
 }
 
-// getPluginAsset polls till it finds the plugin tar file.
-func getPluginAsset(ctx context.Context, release *github.RepositoryRelease) (*github.ReleaseAsset, error) {
-	LogInfo("Checking if the release asset is available")
+// getPluginAsset polls till it finds the plugin tar file. If no asset
+// name provided, it will ensure that there is only one .tar.gz file
+// and use it instead
+func getPluginAsset(ctx context.Context, release *github.RepositoryRelease, assetName string) (*github.ReleaseAsset, error) {
+	if (assetName != "") {
+		LogInfo("Checking if the release asset with name %q is available", assetName)
+	} else {
+		LogInfo("Checking if the release asset is available")
+	}
 
 	ctx, cancel := context.WithTimeout(ctx, pluginAssetTimeout)
 	defer cancel()
@@ -549,10 +555,15 @@ func getPluginAsset(ctx context.Context, release *github.RepositoryRelease) (*gi
 	for {
 		var foundPluginAsset *github.ReleaseAsset
 		for i := range release.Assets {
-			assetName := release.Assets[i].GetName()
-			if strings.HasSuffix(assetName, ".tar.gz") {
+			name := release.Assets[i].GetName()
+			if (assetName != "") {
+				if (assetName == name) {
+					foundPluginAsset = &release.Assets[i]
+					break
+				}
+			} else if strings.HasSuffix(name, ".tar.gz") {
 				if foundPluginAsset != nil {
-					return nil, errors.Errorf("found unexpected file %s", assetName)
+					return nil, errors.Errorf("found unexpected file %s", name)
 				}
 				foundPluginAsset = &release.Assets[i]
 			}

--- a/server/plugin_release.go
+++ b/server/plugin_release.go
@@ -543,7 +543,7 @@ func getPluginRelease(ctx context.Context, githubClient *GithubClient, owner, re
 // name provided, it will ensure that there is only one .tar.gz file
 // and use it instead
 func getPluginAsset(ctx context.Context, release *github.RepositoryRelease, assetName string) (*github.ReleaseAsset, error) {
-	if (assetName != "") {
+	if assetName != "" {
 		LogInfo("Checking if the release asset with name %q is available", assetName)
 	} else {
 		LogInfo("Checking if the release asset is available")
@@ -556,8 +556,8 @@ func getPluginAsset(ctx context.Context, release *github.RepositoryRelease, asse
 		var foundPluginAsset *github.ReleaseAsset
 		for i := range release.Assets {
 			name := release.Assets[i].GetName()
-			if (assetName != "") {
-				if (assetName == name) {
+			if assetName != "" {
+				if assetName == name {
 					foundPluginAsset = &release.Assets[i]
 					break
 				}

--- a/server/plugin_release_test.go
+++ b/server/plugin_release_test.go
@@ -321,8 +321,8 @@ func TestGetPluginAsset(t *testing.T) {
 
 	t.Run("should find the tarball if only one exists", func(t *testing.T) {
 		release.Assets = []github.ReleaseAsset{
-			{ ID: github.Int64(1), Name: github.String("README.txt") },
-			{ ID: github.Int64(2), Name: github.String("tarball.tar.gz") },
+			{ID: github.Int64(1), Name: github.String("README.txt")},
+			{ID: github.Int64(2), Name: github.String("tarball.tar.gz")},
 		}
 
 		asset, err := getPluginAsset(ctx, release, "")
@@ -332,8 +332,8 @@ func TestGetPluginAsset(t *testing.T) {
 
 	t.Run("should error if more than one tarball exists", func(t *testing.T) {
 		release.Assets = []github.ReleaseAsset{
-			{ ID: github.Int64(1), Name: github.String("tarball.tar.gz") },
-			{ ID: github.Int64(2), Name: github.String("plugin-tarball.tar.gz") },
+			{ID: github.Int64(1), Name: github.String("tarball.tar.gz")},
+			{ID: github.Int64(2), Name: github.String("plugin-tarball.tar.gz")},
 		}
 
 		asset, err := getPluginAsset(ctx, release, "")
@@ -343,8 +343,8 @@ func TestGetPluginAsset(t *testing.T) {
 
 	t.Run("should find a specific asset if a name is passed", func(t *testing.T) {
 		release.Assets = []github.ReleaseAsset{
-			{ ID: github.Int64(1), Name: github.String("tarball.tar.gz") },
-			{ ID: github.Int64(2), Name: github.String("plugin-tarball.tar.gz") },
+			{ID: github.Int64(1), Name: github.String("tarball.tar.gz")},
+			{ID: github.Int64(2), Name: github.String("plugin-tarball.tar.gz")},
 		}
 
 		asset, err := getPluginAsset(ctx, release, "plugin-tarball.tar.gz")

--- a/server/plugin_release_test.go
+++ b/server/plugin_release_test.go
@@ -315,6 +315,44 @@ func TestCreateTag(t *testing.T) {
 	})
 }
 
+func TestGetPluginAsset(t *testing.T) {
+	ctx := context.Background()
+	release := &github.RepositoryRelease{}
+
+	t.Run("should find the tarball if only one exists", func(t *testing.T) {
+		release.Assets = []github.ReleaseAsset{
+			{ ID: github.Int64(1), Name: github.String("README.txt") },
+			{ ID: github.Int64(2), Name: github.String("tarball.tar.gz") },
+		}
+
+		asset, err := getPluginAsset(ctx, release, "")
+		require.NoError(t, err)
+		require.Equal(t, github.String("tarball.tar.gz"), asset.Name)
+	})
+
+	t.Run("should error if more than one tarball exists", func(t *testing.T) {
+		release.Assets = []github.ReleaseAsset{
+			{ ID: github.Int64(1), Name: github.String("tarball.tar.gz") },
+			{ ID: github.Int64(2), Name: github.String("plugin-tarball.tar.gz") },
+		}
+
+		asset, err := getPluginAsset(ctx, release, "")
+		require.EqualError(t, err, "found unexpected file plugin-tarball.tar.gz")
+		require.Nil(t, asset)
+	})
+
+	t.Run("should find a specific asset if a name is passed", func(t *testing.T) {
+		release.Assets = []github.ReleaseAsset{
+			{ ID: github.Int64(1), Name: github.String("tarball.tar.gz") },
+			{ ID: github.Int64(2), Name: github.String("plugin-tarball.tar.gz") },
+		}
+
+		asset, err := getPluginAsset(ctx, release, "plugin-tarball.tar.gz")
+		require.NoError(t, err)
+		require.Equal(t, github.String("plugin-tarball.tar.gz"), asset.Name)
+	})
+}
+
 func TestDownloadAsset(t *testing.T) {
 	t.Run("should error if nothing is downloaded", func(t *testing.T) {
 		ctrl := gomock.NewController(t)


### PR DESCRIPTION
#### Summary
This PR adds support for an `--asset-name` flag in the `cutplugin` command, to support to reference a given asset in the release to sign instead of forcing for only one tarball to be present. The use case that triggered this need is the focalboard release, where we want to include several tarball assets in the same release, and only add the signature for the plugin one.