### PR TITLE
Add support for plugins using main as their branch, instead of master

### DIFF
--- a/server/github_client.go
+++ b/server/github_client.go
@@ -13,6 +13,7 @@ import (
 )
 
 type GithubRepositoriesService interface {
+	Get(ctx context.Context, owner, repo string) (*github.Repository, *github.Response, error)
 	GetCommit(ctx context.Context, owner, repo, sha string) (*github.RepositoryCommit, *github.Response, error)
 	ListTags(ctx context.Context, owner, repo string, opt *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error)
 	GetReleaseByTag(ctx context.Context, owner, repo, tag string) (*github.RepositoryRelease, *github.Response, error)

--- a/server/mocks/mock_github_repo.go
+++ b/server/mocks/mock_github_repo.go
@@ -83,6 +83,22 @@ func (mr *MockGithubRepositoriesServiceMockRecorder) EditRelease(arg0, arg1, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EditRelease", reflect.TypeOf((*MockGithubRepositoriesService)(nil).EditRelease), arg0, arg1, arg2, arg3, arg4)
 }
 
+// Get mocks base method
+func (m *MockGithubRepositoriesService) Get(arg0 context.Context, arg1, arg2 string) (*github.Repository, *github.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*github.Repository)
+	ret1, _ := ret[1].(*github.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// Get indicates an expected call of Get
+func (mr *MockGithubRepositoriesServiceMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockGithubRepositoriesService)(nil).Get), arg0, arg1, arg2)
+}
+
 // GetCommit mocks base method
 func (m *MockGithubRepositoriesService) GetCommit(arg0 context.Context, arg1, arg2, arg3 string) (*github.RepositoryCommit, *github.Response, error) {
 	m.ctrl.T.Helper()

--- a/server/plugin_release.go
+++ b/server/plugin_release.go
@@ -162,7 +162,11 @@ func createTag(ctx context.Context, client *GithubClient, owner, repository, tag
 		var ref *github.Reference
 		ref, _, err = client.Git.GetRef(ctx, owner, repository, "heads/master")
 		if err != nil {
-			return errors.Wrap(err, "failed to get github ref")
+			// perhaps the repo uses main instead?
+			ref, _, err = client.Git.GetRef(ctx, owner, repository, "heads/main")
+		}
+		if err != nil {
+			return errors.Wrap(err, "failed to get github ref for heads/master or heads/main")
 		}
 
 		commitSHA = *ref.Object.SHA

--- a/server/plugin_release_test.go
+++ b/server/plugin_release_test.go
@@ -170,15 +170,22 @@ func TestCreateTag(t *testing.T) {
 		ctx := context.Background()
 
 		gitMock := mocks.NewMockGithubGitService(ctrl)
+		repoMock := mocks.NewMockGithubRepositoriesService(ctrl)
 		owner := "owner"
 		repoName := "repoName"
 		tag := "testTag"
 		commitSHA := ""
 
 		testClient := &GithubClient{
-			Git: gitMock,
+			Git:          gitMock,
+			Repositories: repoMock,
 		}
 		gitMock.EXPECT().GetRefs(gomock.Eq(ctx), gomock.Eq(owner), gomock.Eq(repoName), gomock.Eq(fmt.Sprintf("tags/%s", tag))).Return(nil, nil, nil)
+
+		repo := &github.Repository{
+			DefaultBranch: github.String("master"),
+		}
+		repoMock.EXPECT().Get(gomock.Eq(ctx), gomock.Eq(owner), gomock.Eq(repoName)).Return(repo, nil, nil)
 
 		masterRef := &github.Reference{
 			Object: &github.GitObject{


### PR DESCRIPTION
#### Summary
- Some plugins (like calls) use `main` as their main branch, instead of `master`

#### Ticket Link
`none`