### PR TITLE
Fix get default branch for plugins

### DIFF
--- a/server/plugin_release.go
+++ b/server/plugin_release.go
@@ -161,12 +161,10 @@ func createTag(ctx context.Context, client *GithubClient, owner, repository, tag
 		// Use the default branch's tip if commitSHA is not provided, or master if not available
 		var repo *github.Repository
 		repo, _, err = client.Repositories.Get(ctx, owner, repository)
-		var branch string
-		if err != nil {
-			branch = repo.GetDefaultBranch()
-		}
-		if branch == "" {
-			branch = "master"
+
+		branch := "master"
+		if err != nil && repo.DefaultBranch != nil && *repo.DefaultBranch != "" {
+			branch = *repo.DefaultBranch
 		}
 
 		var ref *github.Reference

--- a/server/plugin_release.go
+++ b/server/plugin_release.go
@@ -163,8 +163,8 @@ func createTag(ctx context.Context, client *GithubClient, owner, repository, tag
 		repo, _, err = client.Repositories.Get(ctx, owner, repository)
 
 		branch := "master"
-		if err != nil && repo.DefaultBranch != nil && *repo.DefaultBranch != "" {
-			branch = *repo.DefaultBranch
+		if err == nil && repo.GetDefaultBranch() != "" {
+			branch = repo.GetDefaultBranch()
 		}
 
 		var ref *github.Reference


### PR DESCRIPTION
#### Summary
- ~~For some reason `GetDefaultBranch()` was not working as expected~~ Nope, the reason was I was so used to typing `err != nil` that I made a bug. Fixed now. 😅 

#### Ticket Link
- none